### PR TITLE
Header initial concept

### DIFF
--- a/assets/css/Header/header.css
+++ b/assets/css/Header/header.css
@@ -1,0 +1,23 @@
+.h-container {
+  width: 100%;
+  height: 10rem;
+
+  background: linear-gradient(to right, #717171, #959595);
+
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  /* padding: 0 3.2rem; */
+
+}
+
+.h-container nav ul {
+  display: flex;
+  gap: 1.5rem;
+}
+
+ul li {
+  transform: translateY(-4px);
+}
+
+

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -18,8 +18,11 @@ ul {
 }
 
 a {
-  font-style: none;
-  color: inherit;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: #fff;
+  font-family: var(--font-head1);
+  font-size: 1.8rem;
 }
 
 img {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,1 +1,2 @@
-@import 'global.css'
+@import 'global.css';
+@import './Header/header.css'

--- a/index.html
+++ b/index.html
@@ -13,6 +13,18 @@
     <title>Subaru BRZ</title>
   </head>
   <body>
+    <header>
+      <div class="h-container">
+        <a href=""><img src="./assets/imgs/subaru_logo.png" alt="Subaru"></a>
+        <nav>
+          <ul>
+            <li><a href="/">Montar</a></li>
+            <li><a href="#">Sobre</a></li>
+            <li><a href="#">Contato</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
     <script type="module" src="/assets/js/script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Mudanças:
---
![image](https://github.com/user-attachments/assets/b3794d40-bd2b-43da-9e00-848a16566a39)
---
- Mais sentido a navegação ir para parte de montar (slide) que será a segunda sessão do site.
- Botão de início (retornar ao início) ficará no logotipo.
- Alinhamento através do space around (flex) : sujeito ainda a mudanças.